### PR TITLE
[W7.8a][W12-2]Lee Geng Yu

### DIFF
--- a/src/seedu/addressbook/ui/DarkTheme.css
+++ b/src/seedu/addressbook/ui/DarkTheme.css
@@ -2,16 +2,17 @@
 
 .text-field {
     -fx-font-size: 12pt;
-    -fx-font-family: "Consolas";
+    -fx-font-family: "Arial";
     -fx-font-weight: bold;
-    -fx-text-fill: yellow;
+    -fx-text-fill: white;
     -fx-control-inner-background: derive(#1d1d1d,20%);
 }
 
 .text-area {
-    -fx-background-color: black;
-    -fx-control-inner-background: black;
-    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-family: "Arial";
     -fx-font-size: 10pt;
-    -fx-padding: 5 5 5 5;
+    -fx-padding: 5 400 5 5;
+    -fx-background-image: url("/seedu/addressbook/ui/NUSLogo.jpg");
+    -fx-background-size: 50% 100%;
 }
+


### PR DESCRIPTION
Some enhancements were done to the AddressBook GUI:

1. Half the text-area displays a NUS logo (not aesthetically-sized, and is out-of-shape if the GUI is expanded to full-size; tried many configurations but settled for this for now). The (inner) background of the other-half of the text-area was changed to white.
2. The font-family for both the text-field and text-areas were standardised to Arial.
3. The text colour in text-field (top-bar, where users enter in their commands) is changed to white.
![image](https://user-images.githubusercontent.com/35021368/46243064-356b4000-c402-11e8-94f0-9aef2fb9f777.png)
